### PR TITLE
Add thorough CoffeeMachine coverage tests

### DIFF
--- a/src/test/java/org/example/MainTest.java
+++ b/src/test/java/org/example/MainTest.java
@@ -3,49 +3,138 @@ package org.example;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
-
-//mvn test-compile org.pitest:pitest-maven:mutationCoverage
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class MainTest {
-    private Main.CoffeeMachine coffeeMachine;
+
+    private static class TestableCoffeeMachine extends Main.CoffeeMachine {
+        void forceState(State state) {
+            this.currentState = state;
+        }
+    }
+
+    private TestableCoffeeMachine coffeeMachine;
 
     @BeforeEach
-    public void setUp() {
-        coffeeMachine = new Main.CoffeeMachine();
-    }
-
-    @Test
-    public void testStartBrewing_OffState() {
-        coffeeMachine.powerOff();
-        coffeeMachine.startBrewing();
-        assertEquals(Main.CoffeeMachine.State.ERROR, coffeeMachine.getCurrentState());
-
-    }
-
-    @Test
-    public void testStartGetNumberCoffee0() {
+    void setUp() {
         Main.CoffeeMachine.setNumberCoffees(0);
-        coffeeMachine.powerOn();
-        assertEquals(Main.CoffeeMachine.State.IDLE, coffeeMachine.getCurrentState());
-
-        int c = Main.CoffeeMachine.getNumberCoffees();
-        assertEquals(0, c);
-
-        Main.CoffeeMachine.setNumberCoffees(2);
-        c = Main.CoffeeMachine.getNumberCoffees();
-        assertEquals(2, c);
-
-        // increase coverage of setnumber
-        Main.CoffeeMachine.setNumberCoffees(3);
-        c = Main.CoffeeMachine.getNumberCoffees();
-        assertEquals(3, c);
-
-
+        coffeeMachine = new TestableCoffeeMachine();
     }
 
+    @Test
+    void testPowerOnTriggersMaintenanceWhenThresholdReached() {
+        Main.CoffeeMachine.setNumberCoffees(3);
+        coffeeMachine.powerOn();
 
+        assertSame(Main.CoffeeMachine.State.IDLE, coffeeMachine.getCurrentState());
+        assertEquals(0, Main.CoffeeMachine.getNumberCoffees());
+    }
 
+    @Test
+    void testPowerOffSetsReadyState() {
+        coffeeMachine.powerOff();
+        assertSame(Main.CoffeeMachine.State.READY, coffeeMachine.getCurrentState());
+    }
 
+    @Test
+    void testSelectCoffeeFromIdleMovesToReady() {
+        coffeeMachine.powerOn();
+        coffeeMachine.selectCoffee();
 
+        assertSame(Main.CoffeeMachine.State.READY, coffeeMachine.getCurrentState());
+    }
+
+    @Test
+    void testSelectCoffeeTriggersMaintenanceBeforeReady() {
+        coffeeMachine.powerOn();
+        Main.CoffeeMachine.setNumberCoffees(3);
+
+        coffeeMachine.selectCoffee();
+
+        assertSame(Main.CoffeeMachine.State.READY, coffeeMachine.getCurrentState());
+        assertEquals(0, Main.CoffeeMachine.getNumberCoffees());
+    }
+
+    @Test
+    void testSelectCoffeeWhenNotIdleTriggersError() {
+        coffeeMachine.selectCoffee();
+        assertSame(Main.CoffeeMachine.State.ERROR, coffeeMachine.getCurrentState());
+    }
+
+    @Test
+    void testStartBrewingFromReadyCompletesCycle() {
+        coffeeMachine.powerOn();
+        coffeeMachine.selectCoffee();
+
+        coffeeMachine.startBrewing();
+
+        assertSame(Main.CoffeeMachine.State.IDLE, coffeeMachine.getCurrentState());
+        assertEquals(1, Main.CoffeeMachine.getNumberCoffees());
+    }
+
+    @Test
+    void testStartBrewingFromInvalidStateEntersError() {
+        coffeeMachine.startBrewing();
+        assertSame(Main.CoffeeMachine.State.ERROR, coffeeMachine.getCurrentState());
+    }
+
+    @Test
+    void testStartBrewingWhenMaintenanceRequired() {
+        coffeeMachine.forceState(Main.CoffeeMachine.State.READY);
+        Main.CoffeeMachine.setNumberCoffees(3);
+
+        coffeeMachine.startBrewing();
+
+        assertSame(Main.CoffeeMachine.State.IDLE, coffeeMachine.getCurrentState());
+        assertEquals(0, Main.CoffeeMachine.getNumberCoffees());
+    }
+
+    @Test
+    void testHeatingWaterTransitionsWhenBrewing() {
+        coffeeMachine.forceState(Main.CoffeeMachine.State.BREWING);
+
+        coffeeMachine.heatingWater();
+
+        assertSame(Main.CoffeeMachine.State.HEATING_WATER, coffeeMachine.getCurrentState());
+    }
+
+    @Test
+    void testHeatingWaterWhenNotBrewingCausesError() {
+        coffeeMachine.heatingWater();
+        assertSame(Main.CoffeeMachine.State.ERROR, coffeeMachine.getCurrentState());
+    }
+
+    @Test
+    void testGrindingBeansTransitionsWhenHeatingWater() {
+        coffeeMachine.forceState(Main.CoffeeMachine.State.HEATING_WATER);
+
+        coffeeMachine.grindingBeans();
+
+        assertSame(Main.CoffeeMachine.State.GRINDING_BEANS, coffeeMachine.getCurrentState());
+    }
+
+    @Test
+    void testGrindingBeansWhenNotHeatingWaterCausesError() {
+        coffeeMachine.grindingBeans();
+        assertSame(Main.CoffeeMachine.State.ERROR, coffeeMachine.getCurrentState());
+    }
+
+    @Test
+    void testPerformMaintenanceWithoutRequirement() {
+        coffeeMachine.performMaintenance();
+        assertSame(Main.CoffeeMachine.State.OFF, coffeeMachine.getCurrentState());
+    }
+
+    @Test
+    void testCoffeeMachineErrorSetsErrorState() {
+        coffeeMachine.coffeeMachineError();
+        assertSame(Main.CoffeeMachine.State.ERROR, coffeeMachine.getCurrentState());
+    }
+
+    @Test
+    void testMainMethodRuns() {
+        Main.main(new String[0]);
+        assertEquals(0, Main.CoffeeMachine.getNumberCoffees());
+    }
 }


### PR DESCRIPTION
## Summary
- add a test-specific CoffeeMachine subclass to drive internal state transitions
- cover each CoffeeMachine operation, including maintenance, errors, and main method execution, to achieve full line coverage

## Testing
- mvn test *(fails: unable to download maven-resources-plugin because Maven Central returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e38122fee08329930b3a109fc7fcdb